### PR TITLE
Update integration tests for home autoconnect

### DIFF
--- a/integration-tests/tests/home_interface_test.go
+++ b/integration-tests/tests/home_interface_test.go
@@ -35,7 +35,8 @@ var _ = check.Suite(&homeInterfaceSuite{
 	interfaceSuite: interfaceSuite{
 		sampleSnaps: []string{data.HomeConsumerSnapName},
 		slot:        "home",
-		plug:        "home-consumer"}})
+		plug:        "home-consumer",
+		autoconnect: true}})
 
 type homeInterfaceSuite struct {
 	interfaceSuite


### PR DESCRIPTION
hey @jdstrand, the integration tests check for autoconnect in the home interface, with this change they should pass.

Thanks! :)
